### PR TITLE
Fix flow label in metrics

### DIFF
--- a/pkg/accumulators/non_blocking_bucket/bucket.go
+++ b/pkg/accumulators/non_blocking_bucket/bucket.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
+const ( //TODO: move this from here into config
 	MINIMAL_QUEUE_CAPACITY = 30
 )
 

--- a/pkg/accumulators/non_blocking_bucket/bucket.go
+++ b/pkg/accumulators/non_blocking_bucket/bucket.go
@@ -55,7 +55,7 @@ func New(
 	metrics.queueCapacity(queueCapacity)
 
 	return &BucketAccumulator{
-		l:                l.With(logger.COMPONENT_KEY, "accumulator", logger.FLOW_KEY, flowName),
+		l:                l.With(logger.COMPONENT_KEY, "accumulator"),
 		limitOfBytes:     limitOfBytes,
 		separator:        separator,
 		separatorLen:     len(separator),

--- a/pkg/accumulators/non_blocking_bucket/metrics.go
+++ b/pkg/accumulators/non_blocking_bucket/metrics.go
@@ -15,49 +15,46 @@ type metricCollector struct {
 	nextCounter        *prometheus.CounterVec
 	capacityGauge      *prometheus.GaugeVec
 	enqueuedItemsGauge *prometheus.GaugeVec
+	flowName           string
 }
 
 func NewMetricCollector(flowName string, metricRegistry *prometheus.Registry) *metricCollector {
 	enqueueCounter := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace:   "jiboia",
-			Subsystem:   "accumulator",
-			Name:        "enqueue_calls_total",
-			Help:        "The total number of times that data was enqueued.",
-			ConstLabels: prometheus.Labels{FLOW_METRIC_KEY: flowName},
+			Namespace: "jiboia",
+			Subsystem: "accumulator",
+			Name:      "enqueue_calls_total",
+			Help:      "The total number of times that data was enqueued.",
 		},
-		[]string{})
+		[]string{FLOW_METRIC_KEY})
 
 	nextCounter := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace:   "jiboia",
-			Subsystem:   "accumulator",
-			Name:        "next_calls_total",
-			Help:        "The total number of times that data was sent to next step.",
-			ConstLabels: prometheus.Labels{FLOW_METRIC_KEY: flowName},
+			Namespace: "jiboia",
+			Subsystem: "accumulator",
+			Name:      "next_calls_total",
+			Help:      "The total number of times that data was sent to next step.",
 		},
-		[]string{})
+		[]string{FLOW_METRIC_KEY})
 
 	capacityGauge := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace:   "jiboia",
-			Subsystem:   "accumulator",
-			Name:        "queue_capacity",
-			Help:        "The total capacity of the internal queue.",
-			ConstLabels: prometheus.Labels{FLOW_METRIC_KEY: flowName},
+			Namespace: "jiboia",
+			Subsystem: "accumulator",
+			Name:      "queue_capacity",
+			Help:      "The total capacity of the internal queue.",
 		},
-		[]string{},
+		[]string{FLOW_METRIC_KEY},
 	)
 
 	enqueuedItemsGauge := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace:   "jiboia",
-			Subsystem:   "accumulator",
-			Name:        "items_in_queue",
-			Help:        "The count of current items in the internal queue.",
-			ConstLabels: prometheus.Labels{FLOW_METRIC_KEY: flowName},
+			Namespace: "jiboia",
+			Subsystem: "accumulator",
+			Name:      "items_in_queue",
+			Help:      "The count of current items in the internal queue.",
 		},
-		[]string{},
+		[]string{FLOW_METRIC_KEY},
 	)
 
 	ensureMetricRegisteringOnce.Do(func() {
@@ -69,21 +66,22 @@ func NewMetricCollector(flowName string, metricRegistry *prometheus.Registry) *m
 		nextCounter:        nextCounter,
 		capacityGauge:      capacityGauge,
 		enqueuedItemsGauge: enqueuedItemsGauge,
+		flowName:           flowName,
 	}
 }
 
 func (m *metricCollector) queueCapacity(queueCapacity int) {
-	m.capacityGauge.WithLabelValues().Set(float64(queueCapacity))
+	m.capacityGauge.WithLabelValues(m.flowName).Set(float64(queueCapacity))
 }
 
 func (m *metricCollector) increaseEnqueueCounter() {
-	m.enqueueCounter.WithLabelValues().Inc()
+	m.enqueueCounter.WithLabelValues(m.flowName).Inc()
 }
 
 func (m *metricCollector) increaseNextCounter() {
-	m.nextCounter.WithLabelValues().Inc()
+	m.nextCounter.WithLabelValues(m.flowName).Inc()
 }
 
 func (m *metricCollector) enqueuedItems(itemsCount int) {
-	m.enqueuedItemsGauge.WithLabelValues().Set(float64(itemsCount))
+	m.enqueuedItemsGauge.WithLabelValues(m.flowName).Set(float64(itemsCount))
 }

--- a/pkg/uploaders/nonblocking_uploader/metrics.go
+++ b/pkg/uploaders/nonblocking_uploader/metrics.go
@@ -15,51 +15,48 @@ type metricCollector struct {
 	workersCountGauge  *prometheus.GaugeVec
 	enqueueCounter     *prometheus.CounterVec
 	enqueuedItemsGauge *prometheus.GaugeVec
+	flowName           string
 }
 
 func NewMetricCollector(flowName string, metricRegistry *prometheus.Registry) *metricCollector {
 	queueCapacityGauge := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace:   "jiboia",
-			Subsystem:   "uploader",
-			Name:        "queue_capacity",
-			Help:        "The total capacity of the internal queue.",
-			ConstLabels: prometheus.Labels{FLOW_METRIC_KEY: flowName},
+			Namespace: "jiboia",
+			Subsystem: "uploader",
+			Name:      "queue_capacity",
+			Help:      "The total capacity of the internal queue.",
 		},
-		[]string{},
+		[]string{FLOW_METRIC_KEY},
 	)
 
 	workersCountGauge := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace:   "jiboia",
-			Subsystem:   "uploader",
-			Name:        "workers_count",
-			Help:        "The total number of workers, meaning how many uploads can happen in parallel.",
-			ConstLabels: prometheus.Labels{FLOW_METRIC_KEY: flowName},
+			Namespace: "jiboia",
+			Subsystem: "uploader",
+			Name:      "workers_count",
+			Help:      "The total number of workers, meaning how many uploads can happen in parallel.",
 		},
-		[]string{},
+		[]string{FLOW_METRIC_KEY},
 	)
 
 	enqueueCounter := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace:   "jiboia",
-			Subsystem:   "uploader",
-			Name:        "enqueue_calls_total",
-			Help:        "The total number of times that data was enqueued.",
-			ConstLabels: prometheus.Labels{FLOW_METRIC_KEY: flowName},
+			Namespace: "jiboia",
+			Subsystem: "uploader",
+			Name:      "enqueue_calls_total",
+			Help:      "The total number of times that data was enqueued.",
 		},
-		[]string{},
+		[]string{FLOW_METRIC_KEY},
 	)
 
 	enqueuedItemsGauge := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace:   "jiboia",
-			Subsystem:   "uploader",
-			Name:        "items_in_queue",
-			Help:        "The count of current items in the internal queue, waiting to be uploaded.",
-			ConstLabels: prometheus.Labels{FLOW_METRIC_KEY: flowName},
+			Namespace: "jiboia",
+			Subsystem: "uploader",
+			Name:      "items_in_queue",
+			Help:      "The count of current items in the internal queue, waiting to be uploaded.",
 		},
-		[]string{},
+		[]string{FLOW_METRIC_KEY},
 	)
 
 	ensureMetricRegisteringOnce.Do(func() {
@@ -71,21 +68,22 @@ func NewMetricCollector(flowName string, metricRegistry *prometheus.Registry) *m
 		workersCountGauge:  workersCountGauge,
 		enqueueCounter:     enqueueCounter,
 		enqueuedItemsGauge: enqueuedItemsGauge,
+		flowName:           flowName,
 	}
 }
 
 func (m *metricCollector) queueCapacity(queueCapacity int) {
-	m.queueCapacityGauge.WithLabelValues().Set(float64(queueCapacity))
+	m.queueCapacityGauge.WithLabelValues(m.flowName).Set(float64(queueCapacity))
 }
 
 func (m *metricCollector) workersCount(workersCount int) {
-	m.workersCountGauge.WithLabelValues().Set(float64(workersCount))
+	m.workersCountGauge.WithLabelValues(m.flowName).Set(float64(workersCount))
 }
 
 func (m *metricCollector) increaseEnqueueCounter() {
-	m.enqueueCounter.WithLabelValues().Inc()
+	m.enqueueCounter.WithLabelValues(m.flowName).Inc()
 }
 
 func (m *metricCollector) enqueuedItems(itemsCount int) {
-	m.enqueuedItemsGauge.WithLabelValues().Set(float64(itemsCount))
+	m.enqueuedItemsGauge.WithLabelValues(m.flowName).Set(float64(itemsCount))
 }

--- a/pkg/uploaders/nonblocking_uploader/non_blocking_uploader.go
+++ b/pkg/uploaders/nonblocking_uploader/non_blocking_uploader.go
@@ -43,7 +43,7 @@ func New(
 		internalDataChan: make(chan []byte, queueCapacity),
 		WorkersReady:     make(chan chan *domain.WorkUnit, workersCount),
 		searchForWork:    make(chan struct{}, 1),
-		log:              l.With(logger.COMPONENT_KEY, "uploader", logger.FLOW_KEY, flowName),
+		log:              l.With(logger.COMPONENT_KEY, "uploader"),
 		dataDropper:      dataDropper,
 		filePathProvider: filePathProvider,
 		metrics:          metrics,

--- a/pkg/uploaders/worker.go
+++ b/pkg/uploaders/worker.go
@@ -27,6 +27,7 @@ type Worker struct {
 	queue                ExternalQueue
 	workVolunteeringChan chan chan *domain.WorkUnit
 	workInFlightGauge    *prometheus.GaugeVec
+	flowName             string
 }
 
 func NewWorker(
@@ -39,13 +40,12 @@ func NewWorker(
 
 	workInFlightGauge := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace:   "jiboia",
-			Subsystem:   "worker",
-			Name:        "work_in_flight",
-			Help:        "How many workers are performing work (vs being idle) right now.",
-			ConstLabels: prometheus.Labels{"flow": flowName},
+			Namespace: "jiboia",
+			Subsystem: "worker",
+			Name:      "work_in_flight",
+			Help:      "How many workers are performing work (vs being idle) right now.",
 		},
-		[]string{})
+		[]string{"flow"})
 
 	ensureSingleMetricRegistration.Do(func() {
 		metricRegistry.MustRegister(workInFlightGauge)
@@ -59,6 +59,7 @@ func NewWorker(
 		workVolunteeringChan: workVolunteeringChan,
 		workChan:             workChan,
 		workInFlightGauge:    workInFlightGauge,
+		flowName:             flowName,
 	}
 }
 
@@ -76,8 +77,8 @@ func (w *Worker) Run(ctx context.Context) {
 }
 
 func (w *Worker) work(workU *domain.WorkUnit) {
-	w.workInFlightGauge.WithLabelValues().Inc()
-	defer w.workInFlightGauge.WithLabelValues().Dec()
+	w.workInFlightGauge.WithLabelValues(w.flowName).Inc()
+	defer w.workInFlightGauge.WithLabelValues(w.flowName).Dec()
 
 	uploadResult, err := w.storage.Upload(workU)
 

--- a/pkg/uploaders/worker.go
+++ b/pkg/uploaders/worker.go
@@ -53,7 +53,7 @@ func NewWorker(
 
 	workChan := make(chan *domain.WorkUnit, 1)
 	return &Worker{
-		l:                    l.With(logger.COMPONENT_KEY, "worker", logger.FLOW_KEY, flowName),
+		l:                    l.With(logger.COMPONENT_KEY, "worker"),
 		storage:              storage,
 		queue:                extQueue,
 		workVolunteeringChan: workVolunteeringChan,


### PR DESCRIPTION
The problem was that when using a constant the first value registered was always used. So making it dynamic will allow multiple values to be reported on the flow label.