### PR TITLE
Fix decompression latency reporting metric

### DIFF
--- a/pkg/adapters/http_in/ingest_routes.go
+++ b/pkg/adapters/http_in/ingest_routes.go
@@ -187,8 +187,7 @@ func decompress(data []byte, algorithm string, pathForMetrics string, bufferSize
 		return nil, fmt.Errorf("error closing decompressor data: %w", err)
 	}
 
-	elapsedTime := time.Since(timeStart).Seconds()
-	observeDecompressionTime(pathForMetrics, elapsedTime)
+	observeDecompressionTime(pathForMetrics, time.Since(timeStart))
 
 	return decompressedData, nil
 }

--- a/pkg/adapters/http_in/metrics.go
+++ b/pkg/adapters/http_in/metrics.go
@@ -2,6 +2,7 @@ package http_in
 
 import (
 	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -72,8 +73,8 @@ func observeSize(path string, size float64) {
 	sizeHist.WithLabelValues(path).Observe(size)
 }
 
-func observeDecompressionTime(path string, elapsedTime float64) {
-	decompressionLatencyHist.WithLabelValues(path).Observe(elapsedTime)
+func observeDecompressionTime(path string, elapsedTime time.Duration) {
+	decompressionLatencyHist.WithLabelValues(path).Observe(float64(elapsedTime.Milliseconds()))
 }
 
 func increaseDecompressionCount(algorithm string) {


### PR DESCRIPTION
It should be millis instead of seconds.